### PR TITLE
Crypto

### DIFF
--- a/crypto/decrypt.js
+++ b/crypto/decrypt.js
@@ -1,0 +1,21 @@
+const crypto = require('crypto');
+const fs = require('fs');
+
+const privateKey = fs.readFileSync('privkey.priv', 'utf8');
+
+module.exports = {
+	chunk_decrypt: (item_decrypt) => {
+		return crypto.privateDecrypt(privateKey, Buffer.from(item_decrypt, 'base64')).toString('utf8');
+	},
+
+	decrypt: (item_decrypt) => {
+		let decipherString = "";
+		let chunks = item_decrypt.split("==");
+		chunks.forEach((chunk) => {
+			decipherString += chunk.length ? module.exports.chunk_decrypt(chunk + "==") : '';
+		});
+		return decipherString;
+	}
+}
+
+console.log(module.exports.decrypt("gMv/zeyZtNN+XCe+qyNqaQBGHUuclubR262lYPPKA75EskpHm0ljtRVljt1GPhFeYCJuSzXS/52iKSLf7lAjD/WYTgSEV84Al075D1Vbufo3Y4ru6KfeSI2c8odP8LwYTO3Ouf8KpQxBitaBohJBpbhNUs8YxruyLADoX48YmVdm7YERvxlNXGmFGfh27FcJf8BzKMdpb5KkcIB5nrp/AMy3hs+G38omvzscJjL1IV0qpqm6b8xM/oTIhD0ifBT9XtqX98TrhlnOacT1l0vx3xhEg8wMy2JUojgxrgFv61GyqpGDvhWJ82BYODsgOvKi8YnKgTo0XtatyjiFtlFJEyEGysS/4hxhPoE/XY3r5Kwlq3oUof4oEmr6zMFfGmQZnfm5e+sdmLgEq+Sun/DtlWTrEJPHf9+sHKcqlaLwpp4w7K05zFCTyN3CKp1b/HubHHcakg2g9DwqTtebJfFQrv/HVm8Mq0tPe8TJ8ZhqWIeYKipwnYH5Yz7fu7Lsx20g"));

--- a/crypto/decrypt.js
+++ b/crypto/decrypt.js
@@ -1,11 +1,9 @@
 const crypto = require('crypto');
 const fs = require('fs');
 
-const privateKey = fs.readFileSync('privkey.priv', 'utf8');
-
 module.exports = {
 	chunk_decrypt: (item_decrypt) => {
-		return crypto.privateDecrypt(privateKey, Buffer.from(item_decrypt, 'base64')).toString('utf8');
+		return crypto.privateDecrypt(process.env.CRYPTO_PRIVATE, Buffer.from(item_decrypt, 'base64')).toString('utf8');
 	},
 
 	decrypt: (item_decrypt) => {
@@ -17,5 +15,3 @@ module.exports = {
 		return decipherString;
 	}
 }
-
-console.log(module.exports.decrypt("gMv/zeyZtNN+XCe+qyNqaQBGHUuclubR262lYPPKA75EskpHm0ljtRVljt1GPhFeYCJuSzXS/52iKSLf7lAjD/WYTgSEV84Al075D1Vbufo3Y4ru6KfeSI2c8odP8LwYTO3Ouf8KpQxBitaBohJBpbhNUs8YxruyLADoX48YmVdm7YERvxlNXGmFGfh27FcJf8BzKMdpb5KkcIB5nrp/AMy3hs+G38omvzscJjL1IV0qpqm6b8xM/oTIhD0ifBT9XtqX98TrhlnOacT1l0vx3xhEg8wMy2JUojgxrgFv61GyqpGDvhWJ82BYODsgOvKi8YnKgTo0XtatyjiFtlFJEyEGysS/4hxhPoE/XY3r5Kwlq3oUof4oEmr6zMFfGmQZnfm5e+sdmLgEq+Sun/DtlWTrEJPHf9+sHKcqlaLwpp4w7K05zFCTyN3CKp1b/HubHHcakg2g9DwqTtebJfFQrv/HVm8Mq0tPe8TJ8ZhqWIeYKipwnYH5Yz7fu7Lsx20g"));

--- a/crypto/encrypt.js
+++ b/crypto/encrypt.js
@@ -1,12 +1,11 @@
 const crypto = require('crypto');
 const fs = require('fs');
 
-const publicKey = fs.readFileSync('pubkey.pub', 'utf8');
 const chunk_size = 64;
 
 module.exports = {
 	chunk_encrypt: (item_encrypt) => {
-		return crypto.publicEncrypt(publicKey, Buffer.from(item_encrypt)).toString('base64');
+		return crypto.publicEncrypt(process.env.CRYPTO_PUBLIC, Buffer.from(item_encrypt)).toString('base64');
 	},
 	encrypt: (item_encrypt) => {
 		let cryptoString = '';
@@ -15,5 +14,3 @@ module.exports = {
 		return cryptoString;
 	}
 };
-
-console.log(module.exports.encrypt("Hey there!"));

--- a/crypto/encrypt.js
+++ b/crypto/encrypt.js
@@ -1,0 +1,19 @@
+const crypto = require('crypto');
+const fs = require('fs');
+
+const publicKey = fs.readFileSync('pubkey.pub', 'utf8');
+const chunk_size = 64;
+
+module.exports = {
+	chunk_encrypt: (item_encrypt) => {
+		return crypto.publicEncrypt(publicKey, Buffer.from(item_encrypt)).toString('base64');
+	},
+	encrypt: (item_encrypt) => {
+		let cryptoString = '';
+	        for (let index = 0; index < item_encrypt.length - 1; index += chunk_size)
+                	cryptoString += module.exports.chunk_encrypt(item_encrypt.slice(index, index + chunk_size));
+		return cryptoString;
+	}
+};
+
+console.log(module.exports.encrypt("Hey there!"));


### PR DESCRIPTION
Encrypt/decrypt library code for sensitive registration data.

Requires:
- for encrypt: CRYPTO_PUBLIC key in .env: PEM-encoded RSA public key (`ssh-keygen -f ~/.ssh/<keyname>.pub -e -m pem > pubkey.pub`)
- for decrypt: CRYPTO_PRIVATE key in .env: PEM-encoded RSA private key (`ssh-keygen -f ~/.ssh/<keyname>.pub -p -m pem`)

Need to roll:
- Health/C&R insertion flows: data passes through encrypt (requires CRYPTO_PUBLIC in .env); _ensure database can handle large size of encrypted strings_
- **Admin (Local-Side) Script 1**: for running on secure client only (e.g. `dump.js`) that creates sensible _red binder_ output:
  * Per week: campers alphabetized by last name, first name
  * ALL health data rows appended, passed through decrypt (ONLY client side has CRYPTO_PRIVATE .env set -- private key never leaves secured client machine)
- **Admin (Local-Side) Script 2** script that dumps same data, but JUST has MEDS & EPI PEN fields